### PR TITLE
Ignore TAB key in text filter

### DIFF
--- a/compiled/modules/text-filter.js
+++ b/compiled/modules/text-filter.js
@@ -10,6 +10,10 @@ module.exports = function (h, inputClass) {
   var debouncedSearch = debounce(search, this.opts.debounce);
 
   var onKeyUp = function onKeyUp(e) {
+    if (e.keyCode === 9) {
+      return;
+    }
+
     if (e.keyCode === 13) {
       debouncedSearch.clear();
       search.apply(undefined, arguments);

--- a/lib/modules/text-filter.js
+++ b/lib/modules/text-filter.js
@@ -9,6 +9,10 @@
           var debouncedSearch = debounce(search, this.opts.debounce);
 
           var onKeyUp = function (e) {
+            if (e.keyCode === 9) {
+                return;
+            }
+
             if (e.keyCode === 13) {
               debouncedSearch.clear();
               search(...arguments);


### PR DESCRIPTION
Ignoring the TAB key from within `text-filter` prevents resetting the filter value and preserves the (desired) default behaviour of switching the focus to the next input field.